### PR TITLE
Fix grammar name and misspelling

### DIFF
--- a/grammars/treetop grammar.cson
+++ b/grammars/treetop grammar.cson
@@ -2,9 +2,9 @@
   'treetop'
   'tt'
 ]
-'foldingStartMarker': '(module|grammer|rule).*$'
+'foldingStartMarker': '(module|grammar|rule).*$'
 'foldingStopMarker': '^\\s*end'
-'name': 'Treetop Grammar'
+'name': 'Treetop'
 'patterns': [
   {
     'include': '#comment'


### PR DESCRIPTION
The word "Grammar" in the name of the grammar is redundant, so I removed it. And I fixed the misspelling of the word "grammar".
