### PR TITLE
Update regexp for variable.class-instance.treetop

### DIFF
--- a/grammars/treetop grammar.cson
+++ b/grammars/treetop grammar.cson
@@ -81,7 +81,7 @@
         'name': 'keyword.operator.or.treetop'
       }
       {
-        'match': '<\\w+?>'
+        'match': '<(\\w+\\:{2})?\\w+?>'
         'name': 'variable.class-instance.treetop'
       }
       {


### PR DESCRIPTION
Hi @lee-dohm,

I use treetop in my ruby project. There are many kind of operands in my grammar so I decided to group them. Class names of operands in treetop file was changed according this grouping. For example, `Function` became `Operand::Function`, `Integer` became `Operand::Integer`, etc. language-treetop didn’t recognise this new class names because of this double colons in the middle. So this PR fix this issue. Please tell me if there are any cases when it might not work.
